### PR TITLE
feat: add deletion_policy variable to GSuite module

### DIFF
--- a/modules/gsuite_enabled/README.md
+++ b/modules/gsuite_enabled/README.md
@@ -95,6 +95,7 @@ The roles granted are specifically:
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project\_id/regions/$region/subnetworks/$subnet\_id) | `list(string)` | `[]` | no |
 | usage\_bucket\_name | Name of a GCS bucket to store GCE usage reports in (optional) | `string` | `""` | no |
 | usage\_bucket\_prefix | Prefix in the GCS bucket to store GCE usage reports in (optional) | `string` | `""` | no |
+| deletion_policy | The deletion policy for the project. | `string` | `"PREVENT"` | no |
 
 ## Outputs
 

--- a/modules/gsuite_enabled/main.tf
+++ b/modules/gsuite_enabled/main.tf
@@ -100,6 +100,7 @@ module "project-factory" {
   default_service_account           = var.default_service_account
   disable_dependent_services        = var.disable_dependent_services
   default_network_tier              = var.default_network_tier
+  deletion_policy                   = var.deletion_policy
 }
 
 /******************************************

--- a/modules/gsuite_enabled/metadata.display.yaml
+++ b/modules/gsuite_enabled/metadata.display.yaml
@@ -142,3 +142,6 @@ spec:
         usage_bucket_prefix:
           name: usage_bucket_prefix
           title: Usage Bucket Prefix
+        deletion_policy:
+          name: deletion_policy
+          title: Deletion Policy

--- a/modules/gsuite_enabled/metadata.yaml
+++ b/modules/gsuite_enabled/metadata.yaml
@@ -219,6 +219,10 @@ spec:
         description: Default Network Service Tier for resources created in this project. If unset, the value will not be modified. See https://cloud.google.com/network-tiers/docs/using-network-service-tiers and https://cloud.google.com/network-tiers.
         varType: string
         defaultValue: ""
+      - name: deletion_policy
+        description: The deletion policy for the project.
+        varType: string
+        defaultValue: "PREVENT"
     outputs:
       - name: domain
         description: The organization's domain

--- a/modules/gsuite_enabled/variables.tf
+++ b/modules/gsuite_enabled/variables.tf
@@ -244,3 +244,9 @@ variable "default_network_tier" {
   type        = string
   default     = ""
 }
+
+variable "deletion_policy" {
+  description = "The deletion policy for the project."
+  type        = string
+  default     = "PREVENT"
+}


### PR DESCRIPTION
This pull request introduces a new variable, `deletion_policy`, to the `gsuite_enabled` module. The changes include updates to various documentation and configuration files to incorporate this new variable.

### Key Changes:

Documentation Updates:
* [`modules/gsuite_enabled/README.md`](diffhunk://#diff-12404c6defae4a7d1727833cce32d127acb979d8e0ef5e8e432fb8b4631ded70R98): Added a description for the new `deletion_policy` variable.

Configuration Updates:
* [`modules/gsuite_enabled/main.tf`](diffhunk://#diff-d17c6503ac9387969b7711e94ad5d6784cd65e245144cc1a728912a5812fef9aR103): Added `deletion_policy` to the `project-factory` module configuration.
* [`modules/gsuite_enabled/metadata.display.yaml`](diffhunk://#diff-8352e10511e249805ced4785d4c3b699e1684556e47f16a88a29f87d264e0187R145-R147): Included `deletion_policy` in the metadata display configuration.
* [`modules/gsuite_enabled/metadata.yaml`](diffhunk://#diff-6affb2798dc3c4a6b8e912e64f32a83ebf8a91878f5a04512af0e31f5c3fd1e1R222-R225): Added `deletion_policy` to the metadata configuration with a default value of "PREVENT".
* [`modules/gsuite_enabled/variables.tf`](diffhunk://#diff-6fe5d6a6d96b24c4269ba85afb688281d5398709aee4dbcdd687c5d615c047b3R247-R252): Defined the `deletion_policy` variable with a description and default value.